### PR TITLE
Switch to setuptools_scm for versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     packages:
       - pandoc
 install: pip install -r requirements-dev.txt
-script: nosetests
+script: python setup.py test
 deploy:
   - provider: pypi
     user: rjosephwright

--- a/bossimage/__init__.py
+++ b/bossimage/__init__.py
@@ -1,1 +1,4 @@
-__version__ = '0.4.10'
+from pkg_resources import get_distribution
+
+
+__version__ = get_distribution(__name__).version

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ PyYAML==3.12
 requests==2.18.4
 requests-ntlm==1.0.0
 s3transfer==0.1.10
+setuptools-scm==1.15.6
 six==1.10.0
 urllib3==1.22
 voluptuous==0.10.5

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ config = {
     'entry_points': {
         'console_scripts': ['bi = bossimage.cli:main']
     },
-    'name': 'bossimage'
+    'name': 'bossimage',
+    'test_suite': 'nose.collector',
 }
 
 setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import bossimage
-
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 
 def readme():
@@ -34,19 +29,17 @@ def readme():
             return f.read()
 
 
-version = bossimage.__version__
-download_url = 'https://github.com/cloudboss/bossimage/releases/{}'.format(
-    version
-)
-
 config = {
     'description': 'Tool to create AMIs with Ansible',
     'long_description': readme(),
     'author': 'Joseph Wright',
     'url': 'https://github.com/cloudboss/bossimage',
-    'download_url': download_url,
+    'download_url': 'https://pypi.python.org/pypi/friend',
     'author_email': 'joseph@cloudboss.co',
-    'version': version,
+    'setup_requires': [
+        'setuptools_scm',
+    ],
+    'use_scm_version': True,
     'install_requires': [
         'ansible',
         'boto3',


### PR DESCRIPTION
Version is no longer required to be set in code, instead the
setuptools_scm library will retrieve the version from the latest
git tag.