### PR TITLE
Refactor to use `friend` library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ click==6.7
 cryptography==2.0.3
 docutils==0.14
 enum34==1.1.6
+friend==0.1.3
 futures==3.1.1
 idna==2.6
 ipaddress==1.0.18

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ config = {
         'ansible',
         'boto3',
         'click',
+        'friend',
         'pywinrm',
         'voluptuous',
     ],

--- a/tests/bossimage/__init__.py
+++ b/tests/bossimage/__init__.py
@@ -21,6 +21,7 @@ import shutil
 import tempfile
 import time
 
+from friend.utils import cached
 from mock import mock
 
 import bossimage.core as bc
@@ -88,7 +89,7 @@ def instance_files(instance):
     )
 
 
-@bc.cached
+@cached
 def ec2_connect():
     return mock_ec2()
 

--- a/tests/bossimage/test_core.py
+++ b/tests/bossimage/test_core.py
@@ -20,6 +20,7 @@
 import os
 import StringIO
 
+from friend.strings import random_alphanum
 import mock
 from nose.tools import assert_equal, assert_raises, assert_true
 
@@ -226,7 +227,7 @@ def test_load_config_minimal():
 
 
 def test_load_config_not_found():
-    nosuchfile = bc.random_string(100)
+    nosuchfile = random_alphanum(100)
 
     with assert_raises(bc.ConfigurationError) as r:
         bc.load_config(nosuchfile)


### PR DESCRIPTION
The `cloudboss/friend` Python library is now added as a dependency
and functions defined in `bossimage` which have a counterpart in
that library are being removed here.