### PR TITLE
Make boto3 ec2 resource be explicitly passed

### DIFF
--- a/tests/bossimage/__init__.py
+++ b/tests/bossimage/__init__.py
@@ -21,7 +21,6 @@ import shutil
 import tempfile
 import time
 
-from friend.utils import cached
 from mock import mock
 
 import bossimage.core as bc
@@ -89,7 +88,6 @@ def instance_files(instance):
     )
 
 
-@cached
 def ec2_connect():
     return mock_ec2()
 


### PR DESCRIPTION
To make for better testability, make the ec2 resource object be
an explicit argument for the functions that are using it. The
resource objects are now initialized in cli handlers and passed on
from there.