### PR TITLE
Fix hardcoding of requirements file

### DIFF
--- a/bossimage/core.py
+++ b/bossimage/core.py
@@ -407,7 +407,7 @@ def run_ansible(verbosity, inventory, playbook, extra_vars, requirements):
     if os.path.exists(requirements):
         ansible_galaxy_args = [
             'ansible-galaxy', 'install',
-            '-r', 'requirements.yml',
+            '-r', requirements,
             '-p', roles_path,
         ]
         if verbosity:


### PR DESCRIPTION
The ansible-galaxy requirments file is passed in as a variable,
but the ansible-galaxy command was using a hard coded value
instead of the variable.